### PR TITLE
Repositories should extend CrudRepository<> instead of JpaRepository<>

### DIFF
--- a/src/main/java/com/springboot/jpaspecification/repository/EmployeeRepository.java
+++ b/src/main/java/com/springboot/jpaspecification/repository/EmployeeRepository.java
@@ -3,12 +3,13 @@ package com.springboot.jpaspecification.repository;
 import com.springboot.jpaspecification.entity.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.CrudRepository;
 
 /**
  * Repository interface for performing CRUD and specification-based operations on {@link Employee} entities.
  * Extends the Spring Data JPA {@link JpaRepository} interface for common CRUD operations,
  * and the {@link JpaSpecificationExecutor} interface for handling specification-based queries.
  */
-public interface EmployeeRepository extends JpaRepository<Employee,Long>, JpaSpecificationExecutor<Employee> {
+public interface EmployeeRepository extends CrudRepository<Employee,Long>, JpaSpecificationExecutor<Employee> {
 
 }


### PR DESCRIPTION
JpaRepository extends QueryByExampleExecutor<T> interface which works similar as Specification.

Check documents:
https://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa/repository/JpaRepository.html